### PR TITLE
Adding check for CMIP7 output requirements: calendar attribute

### DIFF
--- a/checks/time_checks/check_time_calendar.py
+++ b/checks/time_checks/check_time_calendar.py
@@ -1,0 +1,51 @@
+import compliance_checker.cf.util as cfutil
+from compliance_checker.base import BaseCheck, TestCtx
+from compliance_checker.cf import util
+
+from checks.utils import severity_word
+
+
+def check_calendar_cmip7(ds, severity=BaseCheck.MEDIUM):
+    """
+    Checks if the "standard" calendar is used, and if so, promotes the use of "proleptic_gregorian" instead.
+
+    1. The "standard" calendar includes "missing" dates in the transition from Gregorian to Julian, causing confusion.
+    2. In the period following the Julian period (i.e., after October 1582) the "proleptic_gregorian" calendar is no different from the "standard" calendar.
+    3. CF conventions 3.14 recommends that models avoid adopting the "standard" calendar.
+    This check can likely be removed once a comparable check is implemented in the CF checker.
+
+    Parameters
+    ----------
+    CheckerObject : WCRPBaseCheck object
+        The initialized WCRPBaseCheck object for the project/dataset being checked.
+    severity : str
+        The severity of the check. Default: BaseCheck.MEDIUM.
+
+    Returns
+    -------
+    List of compliance_checker.base.Result
+    """
+    check_id = "C7OR001"
+    desc = f"[{check_id}] CMIP7 Output Requirements - calendar attribute"
+    testctx = TestCtx(severity, desc)
+    failure_registered = False
+
+    # This will only fetch variables with time units defined
+    # (adapted from CF checker's `check_calendar`)
+    for time_var_name in cfutil.get_time_variables(ds):
+        if time_var_name not in {var.name for var in util.find_coord_vars(ds)}:
+            continue
+        time_var = ds.variables[time_var_name]
+        # If has a calendar, raise an issue if the 'standard' calendar is used
+        if not hasattr(time_var, "calendar"):
+            continue
+        if time_var.calendar.lower() == "standard":
+            err_msg = (
+                f"Variable '{time_var.name}' has a calendar attribute with the value 'standard'. "
+                f"It is {severity_word(severity)} to use 'proleptic_gregorian' instead."
+            )
+            testctx.add_failure(err_msg)
+            failure_registered = True
+    if not failure_registered:
+        testctx.add_pass()
+    return [testctx.to_result()]

--- a/plugins/cmip7/cmip7.py
+++ b/plugins/cmip7/cmip7.py
@@ -30,6 +30,7 @@ from checks.consistency_checks.check_attributes_match_filename import check_file
     _parse_filename_components
 from checks.time_checks.check_time_bounds import check_time_bounds
 from checks.time_checks.check_time_range_vs_filename import *
+from checks.time_checks.check_time_calendar import check_calendar_cmip7
 from checks.data_plausibility_checks.check_nan_inf import check_nan_inf
 from checks.data_plausibility_checks.check_fill_missing import check_fillvalues_timeseries
 from checks.data_plausibility_checks.check_constant import check_constants
@@ -503,6 +504,27 @@ class Cmip7ProjectCheck(WCRPBaseCheck):
                 ds=ds,
                 severity=self.get_severity(check_config.get('severity')),
                 project_id=project_id
+            ))
+
+        return results
+
+
+    def check_cmip7_output_requirements(self, ds):
+        """
+        Checks the compliance with CMIP7 Output Requirements.
+        """
+        results = []
+
+        # Load configuration section
+        if "cmip7_output_requirements" not in self.config:
+            return results
+        config = self.config["cmip7_output_requirements"]
+
+        # Prefer "proleptic_gregorian" calendar over "standard" calendar
+        if config.get("calendar", {}).get("enabled", False):
+            results.extend(check_calendar_cmip7(
+                ds=ds,
+                severity=self.get_severity(config["calendar"].get("severity"))
             ))
 
         return results

--- a/plugins/cmip7/resources/wcrp_config.toml
+++ b/plugins/cmip7/resources/wcrp_config.toml
@@ -8,15 +8,15 @@ project_version = "1.0"
 #  Important Notes
 # ==============================================================================
 
-#  
-* Many of the DRS, CV, and variable registry checks will not pass or run correctly at the moment :
-   	- This is expected, because the esgvoc library does not yet include the CMIP7 controlled vocabulary definitions required for validation.
-   	
-* The variable mapping file (mapping_variables.toml) currently acts as a temporary bridge, manually linking table and variable identifiers for CMIP7 datasets
-		
-* Once ESGVOC provides official CMIP7 vocabulary support, this mapping file will no longer be needed : 
-    	- CMIP7 introduces a global attribute suffix branded variable that removes the need for hard-coded mapping between table_id and variable_id.
-   	- When that feature becomes operational in the CMIP7 CV, the plugin will dynamically resolve variable identities without local TOML mappings."
+#
+#* Many of the DRS, CV, and variable registry checks will not pass or run correctly at the moment :
+#   	- This is expected, because the esgvoc library does not yet include the CMIP7 controlled vocabulary definitions required for validation.
+#
+#* The variable mapping file (mapping_variables.toml) currently acts as a temporary bridge, manually linking table and variable identifiers for CMIP7 datasets#
+#
+#* Once ESGVOC provides official CMIP7 vocabulary support, this mapping file will no longer be needed :
+#    	- CMIP7 introduces a global attribute suffix branded variable that removes the need for hard-coded mapping between table_id and variable_id.
+#   	- When that feature becomes operational in the CMIP7 CV, the plugin will dynamically resolve variable identities without local TOML mappings."
 
 #------------------------------------------------------------------------------
 # DRS Checks
@@ -29,7 +29,7 @@ severity = "H"
 severity = "H"
 
 #------------------------------------------------------------------------------
-# Global Attributes to check 
+# Global Attributes to check
 # ------------------------------------------------------------------------------
 # ======================================================================
 # == Auto-generated Global Attribute Checks (from attached NetCDF file)
@@ -169,6 +169,14 @@ expected_type = "str"
 #To activate Variable regisrty checks
 [variable_registry_checks]
 severity = "H"
+
+# ==============================================================================
+# == CMIP7 Output Requirements Checks
+# ==============================================================================
+[cmip7_output_requirements.calendar]
+enabled = true
+severity = "M"
+
 # ==============================================================================
 # == Data Plausibility Checks
 # ==============================================================================
@@ -214,7 +222,7 @@ severity = "M"
   severity = "H"
   [consistency_checks.experiment_details]
   severity = "H"
-  
+
   [consistency_checks.institution_details]
   severity = "H"
 

--- a/plugins/wcrp_base.py
+++ b/plugins/wcrp_base.py
@@ -62,6 +62,11 @@ class WCRPBaseCheck(BaseCheck):
         self.config = None
         self.project_config_path = None  # To be set by the specific WCRP plugin class
 
+    def __del__(self):
+        xrds = getattr(self, "xrds", None)
+        if xrds is not None and hasattr(xrds, "close"):
+            xrds.close()
+
     def setup(self, dataset):
         """
         Base checker setup


### PR DESCRIPTION
The CMIP7 Output Requirements recommend the usage of the `proleptic_gregorian` calendar instead of the `standard` calendar:
    1. The `standard` calendar includes **missing** dates in the transition from Gregorian to Julian, causing confusion.
    2. In the period following the Julian period (i.e., after October 1582) the `proleptic_gregorian` calendar is no different from the `standard` calendar.
    3. CF conventions 3.14 will recommend that models avoid adopting the "standard" calendar. How that will look in practice and whether this check can then be removed in favour of a similar CF check will have to be seen.

This PR also includes a small fix for the `wcrp_base` checker:
Closing the `xarray.Dataset` after the checker finishes should avoid memory spikes and leaks. While this may not have any effect when running checks on a single file in the command line, it should have a positive effect when running checks on  multiple files using eg. `esgf_qa`.