### PR TITLE
CORDEX-CMIP6 Updates

### DIFF
--- a/checks/attribute_checks/check_attribute_cv.py
+++ b/checks/attribute_checks/check_attribute_cv.py
@@ -5,17 +5,23 @@ from compliance_checker.base import BaseCheck, TestCtx
 from checks.utils import _compare_CV
 
 
-
-def check_required_global_attributes_existence_cv(CheckerObject, severity=BaseCheck.HIGH):
+def check_required_global_attributes_existence_cv(
+    CheckerObject, severity=BaseCheck.HIGH, use_esgvoc=False
+):
     """[ATTR001] Checks existence of required global attributes against <project>_CV.json."""
     check_id = "ATTR001"
     desc = f"[{check_id}] Global Attribute Existence"
     testctx = TestCtx(severity, desc)
 
+    # Do not run comparison against CV if esgvoc is used
+    if use_esgvoc:
+        testctx.add_pass()
+        return [testctx.to_result()]
+
     required_attributes = CheckerObject.CV.get("required_global_attributes", {})
 
     for attr in required_attributes:
-        test = attr in list(CheckerObject.dataset.ncattrs())        
+        test = attr in list(CheckerObject.dataset.ncattrs())
         if not test:
             testctx.add_failure(f"Required global attribute '{attr}' is missing.")
         else:
@@ -24,11 +30,21 @@ def check_required_global_attributes_existence_cv(CheckerObject, severity=BaseCh
     return [testctx.to_result()]
 
 
-def check_required_global_attributes_value_cv(CheckerObject, global_attrs_hard_checks = [], severity=BaseCheck.HIGH):
+def check_required_global_attributes_value_cv(
+    CheckerObject,
+    global_attrs_hard_checks=[],
+    severity=BaseCheck.HIGH,
+    use_esgvoc=False,
+):
     """[ATTR004] Checks value of required global attributes against <project>_CV.json."""
     check_id = "ATTR004"
     desc = f"[{check_id}] Global Attribute Value"
     testctx = TestCtx(severity, desc)
+
+    # Do not run comparison against CV if esgvoc is used
+    if use_esgvoc:
+        testctx.add_pass()
+        return [testctx.to_result()]
 
     required_attributes = CheckerObject.CV.get("required_global_attributes", {})
     file_attrs = {
@@ -39,9 +55,11 @@ def check_required_global_attributes_value_cv(CheckerObject, global_attrs_hard_c
             file_attrs[k] = "unset"
 
     # Global attributes
-    ga_checked, ga_messages = _compare_CV(CheckerObject, file_attrs, "Global attribute ")
+    ga_checked, ga_messages = _compare_CV(
+        CheckerObject, file_attrs, "Global attribute "
+    )
     if len(ga_messages) == 0:
-        testctx.add_pass()        
+        testctx.add_pass()
     else:
         for message in ga_messages:
             testctx.add_failure(message)

--- a/checks/attribute_checks/check_attrs_cordex_cmip6.py
+++ b/checks/attribute_checks/check_attrs_cordex_cmip6.py
@@ -128,7 +128,7 @@ def check_grid_mapping(CheckerObject, severity=BaseCheck.MEDIUM):
     return [testctx.to_result()]
 
 
-def check_domain_id(CheckerObject, severity=BaseCheck.MEDIUM):
+def check_domain_id(CheckerObject, severity=BaseCheck.MEDIUM, use_esgvoc=False):
     """
     Checks if the domain_id is compliant with the CORDEX-CMIP6 archive specifications.
 
@@ -138,6 +138,8 @@ def check_domain_id(CheckerObject, severity=BaseCheck.MEDIUM):
         The initialized WCRPBaseCheck object for the project/dataset being checked.
     severity : str
         The severity of the check. Default: BaseCheck.MEDIUM.
+    use_esgvoc : bool
+        If True, skip the parts of the check that rely on the CORDEX-CMIP6 CV tables.
 
     Returns
     -------
@@ -179,6 +181,11 @@ def check_domain_id(CheckerObject, severity=BaseCheck.MEDIUM):
     else:
         testctx.add_pass()
 
+    # Do not run comparison against CV if esgvoc is used
+    if use_esgvoc:
+        testctx.add_pass()
+        return [testctx.to_result()]
+
     # Check if domain_id is in the CV
     if domain_id not in CheckerObject.CV["domain_id"]:
         testctx.add_failure(
@@ -190,7 +197,7 @@ def check_domain_id(CheckerObject, severity=BaseCheck.MEDIUM):
     return [testctx.to_result()]
 
 
-def check_institution(CheckerObject, severity=BaseCheck.MEDIUM):
+def check_institution(CheckerObject, severity=BaseCheck.MEDIUM, use_esgvoc=False):
     """
     Checks if the institution is compliant with the CV.
 
@@ -200,6 +207,8 @@ def check_institution(CheckerObject, severity=BaseCheck.MEDIUM):
         The initialized WCRPBaseCheck object for the project/dataset being checked.
     severity : str
         The severity of the check. Default: BaseCheck.MEDIUM.
+    use_esgvoc : bool
+        If True, skip the parts of the check that rely on the CORDEX-CMIP6 CV tables.
 
     Returns
     -------
@@ -208,6 +217,11 @@ def check_institution(CheckerObject, severity=BaseCheck.MEDIUM):
     check_id = "CDXA001"
     desc = f"[{check_id}] institution"
     testctx = TestCtx(severity, desc)
+
+    # Do not run comparison against CV if esgvoc is used
+    if use_esgvoc:
+        testctx.add_pass()
+        return [testctx.to_result()]
 
     # Get institution from global attributes
     institution = CheckerObject._get_attr("institution", default=False)
@@ -266,7 +280,9 @@ def check_references(CheckerObject, severity=BaseCheck.MEDIUM):
     return [testctx.to_result()]
 
 
-def check_version_realization_info(CheckerObject, severity=BaseCheck.MEDIUM):
+def check_version_realization_info(
+    CheckerObject, severity=BaseCheck.MEDIUM, use_esgvoc=False
+):
     """
     Checks if version_realization_info is defined when and as recommended in the CORDEX-CMIP6 archive specifications.
 
@@ -276,6 +292,8 @@ def check_version_realization_info(CheckerObject, severity=BaseCheck.MEDIUM):
         The initialized WCRPBaseCheck object for the project/dataset being checked.
     severity : str
         The severity of the check. Default: BaseCheck.MEDIUM.
+    use_esgvoc : bool
+        If True, skip the parts of the check that rely on the CORDEX-CMIP6 CV tables.
 
     Returns
     -------
@@ -284,6 +302,11 @@ def check_version_realization_info(CheckerObject, severity=BaseCheck.MEDIUM):
     check_id = "CDXA001"
     desc = f"[{check_id}] version_realization_info"
     testctx = TestCtx(severity, desc)
+
+    # Do not run comparison with CV if esgvoc is used
+    if use_esgvoc:
+        testctx.add_pass()
+        return [testctx.to_result()]
 
     if (
         any(
@@ -348,7 +371,9 @@ def check_grid(CheckerObject, severity=BaseCheck.LOW):
     return [testctx.to_result()]
 
 
-def check_version_realization(CheckerObject, severity=BaseCheck.MEDIUM):
+def check_version_realization(
+    CheckerObject, severity=BaseCheck.MEDIUM, use_esgvoc=False
+):
     """
     Checks if version_realization is defined as required in the CORDEX-CMIP6 archive specifications.
 
@@ -358,6 +383,8 @@ def check_version_realization(CheckerObject, severity=BaseCheck.MEDIUM):
         The initialized WCRPBaseCheck object for the project/dataset being checked.
     severity : str
         The severity of the check. Default: BaseCheck.MEDIUM.
+    use_esgvoc : bool
+        If True, skip the parts of the check that rely on the CORDEX-CMIP6 CV tables.
 
     Returns
     -------
@@ -368,6 +395,11 @@ def check_version_realization(CheckerObject, severity=BaseCheck.MEDIUM):
     check_id = "CDXA001"
     desc = f"[{check_id}] version_realization"
     testctx = TestCtx(severity, desc)
+
+    # Do not run comparison with CV if esgvoc is used
+    if use_esgvoc:
+        testctx.add_pass()
+        return [testctx.to_result()]
 
     # Filename
     expected = r"Expected pattern: 'v[1-9]\d*-r[1-9]\d*', eg. 'v1-r3'."
@@ -424,7 +456,9 @@ def check_version_realization(CheckerObject, severity=BaseCheck.MEDIUM):
     return [testctx.to_result()]
 
 
-def check_driving_attributes(CheckerObject, severity=BaseCheck.MEDIUM):
+def check_driving_attributes(
+    CheckerObject, severity=BaseCheck.MEDIUM, use_esgvoc=False
+):
     """
     Checks if all driving attributes are defined as required by the CORDEX-CMIP6 archive specifications.
 
@@ -434,6 +468,8 @@ def check_driving_attributes(CheckerObject, severity=BaseCheck.MEDIUM):
         The initialized WCRPBaseCheck object for the project/dataset being checked.
     severity : str
         The severity of the check. Default: BaseCheck.MEDIUM.
+    use_esgvoc : bool
+        If True, skip the parts of the check that rely on the CORDEX-CMIP6 CV tables.
 
     Returns
     -------
@@ -479,6 +515,10 @@ def check_driving_attributes(CheckerObject, severity=BaseCheck.MEDIUM):
     if not drivs:
         testctx.add_pass()
     else:
+        # Do not run comparison with CV if esgvoc is used
+        if use_esgvoc:
+            testctx.add_pass()
+            return [testctx.to_result()]
         # Abort if driving_source_id undefined or unknown (will cause a failed check elsewhere)
         if not dsi or dsi not in CheckerObject.CV["driving_source_id"]:
             testctx.add_pass()

--- a/checks/consistency_checks/check_attributes_match_filename.py
+++ b/checks/consistency_checks/check_attributes_match_filename.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python
 
 import os
+
 from compliance_checker.base import TestCtx
+
 from checks.utils import _parse_filename_components
 
 # CMIP6: time_range exists in filename, not a GA => parse but don't compare
@@ -46,12 +48,30 @@ _FILENAME_KEYS_CMIP7_COMPARE = [
     "variant_label",
 ]
 
-
-def _is_cmip7(ds) -> bool:
-    try:
-        return str(ds.getncattr("mip_era")).upper() == "CMIP7"
-    except Exception:
-        return False
+# CORDEX-CMIP6: time_range exists in filename, not a GA => parse but don't compare
+_FILENAME_KEYS_CORDEX_CMIP6_PARSE = [
+    "variable_id",
+    "domain_id",
+    "driving_source_id",
+    "driving_experiment_id",
+    "driving_variant_label",
+    "institution_id",
+    "source_id",
+    "version_realization",
+    "frequency",
+    "time_range",
+]
+_FILENAME_KEYS_CORDEX_CMIP6_COMPARE = [
+    "variable_id",
+    "domain_id",
+    "driving_source_id",
+    "driving_experiment_id",
+    "driving_variant_label",
+    "institution_id",
+    "source_id",
+    "version_realization",
+    "frequency",
+]
 
 
 def _parse_cmip7_filename(filename: str):
@@ -76,6 +96,29 @@ def _parse_cmip7_filename(filename: str):
     }
 
 
+def _parse_cordex_cmip6_filename(filename: str):
+    """
+    CORDEX-CMIP6 filename (Archive Specifications v2):
+      <variable_id><domain_id><driving_source_id><driving_experiment_id><driving_variant_label><institution_id><source_id><version_realization><frequency>
+    """
+    stem = filename[:-3] if filename.endswith(".nc") else filename
+    parts = stem.split("_")
+    if len(parts) not in (9, 10):
+        return None
+    return {
+        "variable_id": parts[0],
+        "domain_id": parts[1],
+        "driving_source_id": parts[2],
+        "driving_experiment_id": parts[3],
+        "driving_variant_label": parts[4],
+        "institution_id": parts[5],
+        "source_id": parts[6],
+        "version_realization": parts[7],
+        "frequency": parts[8],
+        "time_range": parts[9] if len(parts) == 10 else None,
+    }
+
+
 def _unwrap_facets(maybe_tuple):
     """
     In this repo, checks.utils._parse_filename_components may return:
@@ -84,12 +127,18 @@ def _unwrap_facets(maybe_tuple):
       - (dict, extra)  <-- this is what broke CMIP6
     We only need the dict.
     """
-    if isinstance(maybe_tuple, tuple) and len(maybe_tuple) > 0 and isinstance(maybe_tuple[0], dict):
+    if (
+        isinstance(maybe_tuple, tuple)
+        and len(maybe_tuple) > 0
+        and isinstance(maybe_tuple[0], dict)
+    ):
         return maybe_tuple[0]
     return maybe_tuple
 
 
-def check_filename_vs_global_attrs(ds, severity, filename_template_keys=None):
+def check_filename_vs_global_attrs(
+    ds, severity, project_id="cmip6", filename_template_keys=None
+):
     """
     [ATTR005] Consistency: Filename vs Global Attributes
 
@@ -110,7 +159,7 @@ def check_filename_vs_global_attrs(ds, severity, filename_template_keys=None):
     filename = os.path.basename(filepath)
 
     # ---------------- CMIP7 branch ----------------
-    if _is_cmip7(ds):
+    if project_id == "cmip7":
         facets = _parse_cmip7_filename(filename)
         if facets is None:
             ctx.add_failure(
@@ -118,9 +167,17 @@ def check_filename_vs_global_attrs(ds, severity, filename_template_keys=None):
             )
             return [ctx.to_result()]
         compare_keys = _FILENAME_KEYS_CMIP7_COMPARE
-
+    # ---------------- CORDEX-CMIP6 branch ----------------
+    elif project_id == "cordex-cmip6":
+        facets = _parse_cordex_cmip6_filename(filename)
+        if facets is None:
+            ctx.add_failure(
+                f"Could not perform check. Reason: Filename '{filename}' does not match expected CORDEX-CMIP6 token count (9 or 10 with time_range)."
+            )
+            return [ctx.to_result()]
+        compare_keys = _FILENAME_KEYS_CORDEX_CMIP6_COMPARE
     # ---------------- CMIP6 (default) branch ----------------
-    else:
+    elif project_id == "cmip6":
         parse_keys = filename_template_keys or _FILENAME_KEYS_CMIP6_PARSE
         facets = _parse_filename_components(filename, parse_keys)
         facets = _unwrap_facets(facets)  # <-- FIX: tuple -> dict
@@ -131,6 +188,11 @@ def check_filename_vs_global_attrs(ds, severity, filename_template_keys=None):
             )
             return [ctx.to_result()]
         compare_keys = _FILENAME_KEYS_CMIP6_COMPARE
+    else:
+        ctx.add_failure(
+            f"Could not perform check. Reason: Unknown project '{project_id}'."
+        )
+        return [ctx.to_result()]
 
     # ---------------- Compare tokens to global attributes ----------------
     failures = []
@@ -143,7 +205,9 @@ def check_filename_vs_global_attrs(ds, severity, filename_template_keys=None):
                     f"Filename component '{key}' ('{file_value}') does not match global attribute ('{attr_value}')."
                 )
         else:
-            ctx.messages.append(f"Global attribute '{key}' not found, skipping comparison.")
+            ctx.messages.append(
+                f"Global attribute '{key}' not found, skipping comparison."
+            )
 
     for f in failures:
         ctx.add_failure(f)

--- a/checks/consistency_checks/check_drs_filename_cv.py
+++ b/checks/consistency_checks/check_drs_filename_cv.py
@@ -1,11 +1,14 @@
 #!/usr/bin/env python
 
 import os
+
 from compliance_checker.base import BaseCheck, TestCtx
+
 from checks.utils import _compare_CV, _find_drs_directory_and_filename
 
 try:
     from esgvoc.apps.drs.validator import DrsValidator
+
     ESG_VOCAB_AVAILABLE = True
 except ImportError:
     ESG_VOCAB_AVAILABLE = False
@@ -52,7 +55,9 @@ def check_drs_filename(ds, severity, project_id="cmip6"):
 
         if file_report.errors:
             error_details = "; ".join(str(e) for e in file_report.errors)
-            ctx.add_failure(f"Filename '{filename}' has validation errors: {error_details}")
+            ctx.add_failure(
+                f"Filename '{filename}' has validation errors: {error_details}"
+            )
         else:
             ctx.add_pass()
 
@@ -91,7 +96,9 @@ def check_drs_directory(ds, severity, project_id="cmip6"):
 
     # Fallback to legacy helper (CMIP6 / CORDEX style)
     if not drs_directory:
-        drs_directory, _, error_msg = _find_drs_directory_and_filename(filepath, project_id)
+        drs_directory, _, error_msg = _find_drs_directory_and_filename(
+            filepath, project_id
+        )
 
     if error_msg:
         ctx.add_failure(error_msg)
@@ -103,15 +110,18 @@ def check_drs_directory(ds, severity, project_id="cmip6"):
 
         if dir_report.errors:
             error_details = "; ".join(str(e) for e in dir_report.errors)
-            ctx.add_failure(f"DRS directory '{drs_directory}' has validation errors: {error_details}")
+            ctx.add_failure(
+                f"DRS directory '{drs_directory}' has validation errors: {error_details}"
+            )
         else:
             ctx.add_pass()
 
     except Exception as e:
-        ctx.add_failure(f"An unexpected error occurred during directory validation: {e}")
+        ctx.add_failure(
+            f"An unexpected error occurred during directory validation: {e}"
+        )
 
     return [ctx.to_result()]
-
 
 
 # ==============================================================================
@@ -122,11 +132,17 @@ def check_drs_filename_cv(
     drs_elements_hard_checks=[],
     project_id="CORDEX-CMIP6",
     severity=BaseCheck.HIGH,
+    use_esgvoc=False,
 ):
     """[FILE001] DRS building blocks in filename checked against CV."""
     check_id = "FILE001"
     description = f"[{check_id}] DRS Filename (against {project_id}_CV.json)"
     testctx = TestCtx(severity, description)
+
+    # Do not run if esgvoc is used
+    if use_esgvoc:
+        testctx.add_pass()
+        return [testctx.to_result()]
 
     # File suffix
     suffix = ".".join(os.path.basename(CheckerObject.filepath).split(".")[1:])
@@ -171,11 +187,17 @@ def check_drs_directory_cv(
     drs_elements_hard_checks,
     project_id="CORDEX-CMIP6",
     severity=BaseCheck.HIGH,
+    use_esgvoc=False,
 ):
     """[FILE001] DRS building blocks in directory path checked against CV."""
     check_id = "FILE001"
     description = f"[{check_id}] DRS Directory Structure (against {project_id}_CV.json)"
     testctx = TestCtx(severity, description)
+
+    # Do not run if esgvoc is used
+    if use_esgvoc:
+        testctx.add_pass()
+        return [testctx.to_result()]
 
     # DRS path
     drs_dir_checked, drs_dir_messages = _compare_CV(

--- a/checks/utils.py
+++ b/checks/utils.py
@@ -417,3 +417,58 @@ def _get_drs_facets(filepath, project_id, dir_template_keys, filename_template_k
 
     except Exception as e:
         return None, None, f"An unexpected error occurred during DRS parsing: {e}"
+
+
+###################################
+# Coordinate Utility Functions
+###################################
+
+
+def convert_lon_360(lon):
+    """Convert longitude to [0, 360)."""
+    lon = np.asarray(lon)
+    return lon % 360.0
+
+
+def convert_lon_180(lon):
+    """Convert longitude to [-180, 180)."""
+    lon = np.asarray(lon)
+    return ((lon + 180.0) % 360.0) - 180.0
+
+
+def crosses_zero_meridian(lon, intv=5.0):
+    """
+    Check if longitude crosses 0-meridian.
+
+    Args:
+        lon (numpy.ndarray): Array of longitudes.
+        intv (float, optional): Requiring longitude in interval [-intv, 0] and [0,intv]
+                                to be classified as crossing 0-meridian. Default is 5.
+
+    Returns:
+        bool: True if longitude crosses 0-meridian.
+    """
+    lon180 = convert_lon_180(lon)
+    return bool(
+        np.any((lon180 > -intv) & (lon180 < 0))
+        and np.any((lon180 > 0) & (lon180 < intv))
+    )
+
+
+def crosses_anti_meridian(lon, intv=5.0):
+    """
+    Check if longitude crosses anti-meridian.
+
+    Args:
+        lon (numpy.ndarray): Array of longitudes.
+        intv (float, optional): Requiring longitude in interval [-intv, 0] and [0,intv]
+                                to be classified as crossing 0-meridian. Default is 5.
+
+    Returns:
+        bool: True if longitude crosses anti-meridian.
+    """
+    lon360 = convert_lon_360(lon)
+    return bool(
+        np.any((lon360 > 180 - intv) & (lon360 < 180))
+        and np.any((lon360 > 180) & (lon360 < 180 + intv))
+    )

--- a/checks/variable_checks/check_coords_cordex_cmip6.py
+++ b/checks/variable_checks/check_coords_cordex_cmip6.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python
 
 
-import xarray as xr
 from compliance_checker.base import BaseCheck, TestCtx
 
-from checks.utils import severity_word
+from checks.utils import crosses_anti_meridian, crosses_zero_meridian, severity_word
 
 
 def check_lon_value_range(CheckerObject, severity=BaseCheck.MEDIUM):
@@ -36,11 +35,17 @@ def check_lon_value_range(CheckerObject, severity=BaseCheck.MEDIUM):
 
     # Get domain_id from global attributes
     domain_id = CheckerObject._get_attr("domain_id", default="")
+    if not isinstance(domain_id, str):
+        domain_id = ""
 
     # Check if longitude coordinates are strictly monotonically increasing
     if lon.ndim != 2:
         testctx.add_failure("The longitude coordinate should have two dimensions.")
-    elif domain_id.startswith('ARC') or domain_id.startswith('ANT'):
+    elif (
+        domain_id.startswith("ARC")
+        or domain_id.startswith("ANT")
+        or (crosses_anti_meridian(lon) and crosses_zero_meridian(lon))
+    ):
         # The polar domains are exempt from monotony tests because they cross both the meridian and anti-meridian
         testctx.add_pass()
     else:

--- a/checks/variable_checks/check_coords_cordex_cmip6.py
+++ b/checks/variable_checks/check_coords_cordex_cmip6.py
@@ -34,9 +34,15 @@ def check_lon_value_range(CheckerObject, severity=BaseCheck.MEDIUM):
         testctx.add_pass()
         return [testctx.to_result()]
 
+    # Get domain_id from global attributes
+    domain_id = CheckerObject._get_attr("domain_id", default=False)
+
     # Check if longitude coordinates are strictly monotonically increasing
     if lon.ndim != 2:
         testctx.add_failure("The longitude coordinate should have two dimensions.")
+    elif domain_id.startswith('ARC') or domain_id.startswith('ANT'):
+        # The polar domains are exempt from monotony tests
+        testctx.add_pass()
     else:
         increasing_0 = ((lon[1:, :].data - lon[:-1, :].data) > 0).all()
         increasing_1 = ((lon[:, 1:].data - lon[:, :-1].data) > 0).all()
@@ -74,13 +80,13 @@ def check_lon_value_range(CheckerObject, severity=BaseCheck.MEDIUM):
         )
 
     # Check if longitude coordinates have absolute values as small as possible
-    abs = (lon > 180).any() and (xr.where(lon >= 180, lon - 360, lon) >= -180).all()
-    if not abs:
-        testctx.add_pass()
-    else:
+    # If values are monotonic increasing, only the case 180 <= lon [< 360] is problematic
+    if lon.min() >= 180:
         testctx.add_failure(
-            "Longitude values are required to take the smalles absolute value in the range [-180, 360]."
+            "Longitude values are required to take the smallest absolute value in the range [-180, 360]."
         )
+    else:
+        testctx.add_pass()
 
     return [testctx.to_result()]
 

--- a/checks/variable_checks/check_coords_cordex_cmip6.py
+++ b/checks/variable_checks/check_coords_cordex_cmip6.py
@@ -35,13 +35,13 @@ def check_lon_value_range(CheckerObject, severity=BaseCheck.MEDIUM):
         return [testctx.to_result()]
 
     # Get domain_id from global attributes
-    domain_id = CheckerObject._get_attr("domain_id", default=False)
+    domain_id = CheckerObject._get_attr("domain_id", default="")
 
     # Check if longitude coordinates are strictly monotonically increasing
     if lon.ndim != 2:
         testctx.add_failure("The longitude coordinate should have two dimensions.")
     elif domain_id.startswith('ARC') or domain_id.startswith('ANT'):
-        # The polar domains are exempt from monotony tests
+        # The polar domains are exempt from monotony tests because they cross both the meridian and anti-meridian
         testctx.add_pass()
     else:
         increasing_0 = ((lon[1:, :].data - lon[:-1, :].data) > 0).all()

--- a/plugins/cmip6/cmip6.py
+++ b/plugins/cmip6/cmip6.py
@@ -502,7 +502,7 @@ class Cmip6ProjectCheck(WCRPBaseCheck):
 
         if c.filename_vs_attributes:
             sev = self.get_severity(c.filename_vs_attributes.severity)
-            res.extend(check_filename_vs_global_attrs(ds, sev))
+            res.extend(check_filename_vs_global_attrs(ds, sev, project_id=self.project_name))
 
         if c.experiment_properties:
             sev = self.get_severity(c.experiment_properties.severity)

--- a/plugins/cmip7/cmip7.py
+++ b/plugins/cmip7/cmip7.py
@@ -488,7 +488,7 @@ class Cmip7ProjectCheck(WCRPBaseCheck):
 
         if c.filename_vs_attributes:
             sev = self.get_severity(c.filename_vs_attributes.severity)
-            res.extend(check_filename_vs_global_attrs(ds, sev))
+            res.extend(check_filename_vs_global_attrs(ds, sev, project_id=self.project_name))
 
         if c.experiment_properties:
             sev = self.get_severity(c.experiment_properties.severity)

--- a/plugins/cordex_cmip6/cordex_cmip6.py
+++ b/plugins/cordex_cmip6/cordex_cmip6.py
@@ -210,7 +210,7 @@ class CordexCmip6ProjectCheck(WCRPBaseCheck):
                 check_format(
                     ds=ds,
                     expected_format=check_config.get("expected_format"),
-                    expected_data_model=check_config.get("expected_data_model"),
+                    allowed_data_models=check_config.get("allowed_data_models"),
                     severity=self.get_severity(check_config.get("severity")),
                 )
             )

--- a/plugins/cordex_cmip6/cordex_cmip6.py
+++ b/plugins/cordex_cmip6/cordex_cmip6.py
@@ -127,39 +127,72 @@ class CordexCmip6ProjectCheck(WCRPBaseCheck):
 
         # Make use of CMOR tables for variable checks
         #  at a later time ESGVOC will be used for variable checks
-        if not self.options.get("tables", False):
-            tables_path = self.options.get(
-                "tables_dir", "~/.wcrp_metadata/cordex-cmip6-cmor-tables"
-            )
-            for table in [
-                "coordinate",
-                "grids",
-                "formula_terms",
-                "CV",
-                "1hr",
-                "6hr",
-                "day",
-                "mon",
-                "fx",
-            ]:
-                filename = "CORDEX-CMIP6_" + table + ".json"
-                url = CORDEX_CMIP6_CMOR_TABLES_URL + filename
-                filename_retrieved = retrieve(
-                    CORDEX_CMIP6_CMOR_TABLES_URL + "CORDEX-CMIP6_" + table + ".json",
-                    filename,
-                    tables_path,
-                    force=self.options.get("force_table_download", False),
+        self.verification_against_tables = True
+        if self.verification_against_tables is True or (
+            "verification_against_tables" in self.options
+            and (
+                self.options["verification_against_tables"] is None
+                or (
+                    isinstance(self.options["verification_against_tables"], bool)
+                    and self.options["verification_against_tables"]
                 )
-                if os.path.basename(os.path.realpath(filename_retrieved)) != filename:
-                    raise AssertionError(
-                        f"Download failed for CV table '{filename_retrieved}' (source: '{url}')."
+                or (
+                    isinstance(self.options["verification_against_tables"], str)
+                    and self.options["verification_against_tables"].lower() != "false"
+                )
+            )
+        ):
+            self.verification_against_tables = True
+            if not self.options.get("tables", False):
+                tables_path = self.options.get(
+                    "tables_dir", "~/.wcrp_metadata/cordex-cmip6-cmor-tables"
+                )
+                for table in [
+                    "coordinate",
+                    "grids",
+                    "formula_terms",
+                    "CV",
+                    "1hr",
+                    "6hr",
+                    "day",
+                    "mon",
+                    "fx",
+                ]:
+                    filename = "CORDEX-CMIP6_" + table + ".json"
+                    url = CORDEX_CMIP6_CMOR_TABLES_URL + filename
+                    filename_retrieved = retrieve(
+                        CORDEX_CMIP6_CMOR_TABLES_URL
+                        + "CORDEX-CMIP6_"
+                        + table
+                        + ".json",
+                        filename,
+                        tables_path,
+                        force="force_table_download" in self.options
+                        and (
+                            self.options["force_table_download"] is None
+                            or (
+                                isinstance(self.options["force_table_download"], bool)
+                                and self.options["force_table_download"]
+                            )
+                            or (
+                                isinstance(self.options["force_table_download"], str)
+                                and self.options["force_table_download"].lower()
+                                != "false"
+                            )
+                        ),
                     )
-
-            self._initialize_CV_info(tables_path)
-            self._initialize_time_info()
-            self._initialize_coords_info()
-        if self.consistency_output:
-            self._write_consistency_output()
+                    if (
+                        os.path.basename(os.path.realpath(filename_retrieved))
+                        != filename
+                    ):
+                        raise AssertionError(
+                            f"Download failed for CV table '{filename_retrieved}' (source: '{url}')."
+                        )
+                self._initialize_CV_info(tables_path)
+                self._initialize_time_info()
+                self._initialize_coords_info()
+            if self.consistency_output:
+                self._write_consistency_output()
 
     def check_format(self, ds):
         """
@@ -350,6 +383,7 @@ class CordexCmip6ProjectCheck(WCRPBaseCheck):
                 check_domain_id(
                     self,
                     severity=self.get_severity(check_config.get("severity")),
+                    use_esgvoc=not self.verification_against_tables,
                 )
             )
 
@@ -359,6 +393,7 @@ class CordexCmip6ProjectCheck(WCRPBaseCheck):
                 check_institution(
                     self,
                     severity=self.get_severity(check_config.get("severity")),
+                    use_esgvoc=not self.verification_against_tables,
                 )
             )
 
@@ -377,6 +412,7 @@ class CordexCmip6ProjectCheck(WCRPBaseCheck):
                 check_version_realization(
                     self,
                     severity=self.get_severity(check_config.get("severity")),
+                    use_esgvoc=not self.verification_against_tables,
                 )
             )
 
@@ -386,6 +422,7 @@ class CordexCmip6ProjectCheck(WCRPBaseCheck):
                 check_version_realization_info(
                     self,
                     severity=self.get_severity(check_config.get("severity")),
+                    use_esgvoc=not self.verification_against_tables,
                 )
             )
 
@@ -404,6 +441,7 @@ class CordexCmip6ProjectCheck(WCRPBaseCheck):
                 check_driving_attributes(
                     self,
                     severity=self.get_severity(check_config.get("severity")),
+                    use_esgvoc=not self.verification_against_tables,
                 )
             )
 
@@ -515,6 +553,7 @@ class CordexCmip6ProjectCheck(WCRPBaseCheck):
                 severity=severity,
                 project_id=project_name,
                 drs_elements_hard_checks=drs_elements_hard_checks,
+                use_esgvoc=not self.verification_against_tables,
             )
         )
 
@@ -525,6 +564,7 @@ class CordexCmip6ProjectCheck(WCRPBaseCheck):
                 severity=severity,
                 project_id=project_name,
                 drs_elements_hard_checks=drs_elements_hard_checks,
+                use_esgvoc=not self.verification_against_tables,
             )
         )
 
@@ -583,6 +623,7 @@ class CordexCmip6ProjectCheck(WCRPBaseCheck):
             check_required_global_attributes_existence_cv(
                 self,
                 severity=severity,
+                use_esgvoc=not self.verification_against_tables,
             )
         )
         # Value
@@ -591,6 +632,7 @@ class CordexCmip6ProjectCheck(WCRPBaseCheck):
                 self,
                 severity=severity,
                 global_attrs_hard_checks=global_attrs_hard_checks,
+                use_esgvoc=not self.verification_against_tables,
             )
         )
         return results
@@ -651,6 +693,7 @@ class CordexCmip6ProjectCheck(WCRPBaseCheck):
                 check_filename_vs_global_attrs(
                     ds=ds,
                     severity=self.get_severity(check_config.get("severity")),
+                    project_id=self.project_name,
                     filename_template_keys=check_config.get("filename_template_keys"),
                 )
             )

--- a/plugins/cordex_cmip6/resources/wcrp_config.toml
+++ b/plugins/cordex_cmip6/resources/wcrp_config.toml
@@ -10,8 +10,8 @@ project_version = "1.0"
 [format_checks.check_format]
 severity = "H"
 expected_format = "HDF5"
-expected_data_model = "NETCDF4_CLASSIC"
-#expected_data_model = "NETCDF4"
+allowed_data_models = ["NETCDF4_CLASSIC"]
+#allowed_data_models = ["NETCDF4", "NETCDF4_CLASSIC"]
 
 [format_checks.check_compression]
 severity = "M"

--- a/plugins/wcrp_base.py
+++ b/plugins/wcrp_base.py
@@ -539,8 +539,10 @@ class WCRPBaseCheck(BaseCheck):
             drs_filename_template = re.findall(
                 r"<([^<>]*)\>", self.CV["DRS"]["filename_template"]
             )
-            self.drs_suffix = ".".join(
-                self.CV["DRS"]["filename_template"].split(".")[1:]
+            if "time_range" not in drs_filename_template:
+                drs_filename_template.append("time_range")
+            self.drs_suffix = (
+                ".".join(self.CV["DRS"]["filename_template"].split(".")[1:]) or "nc"
             )
         except KeyError:
             raise KeyError("The CV does not contain DRS information.")


### PR DESCRIPTION
Updates to CORDEX-CMIP6 checker
- Merging latest changes by @aulemahal to the `check_lon_value_range` check into develop branch
- Updating this check to also skip monotony check if `lon` values cross zero- and anti-meridian
- Update DRS template interpretation to support CMIP6- and CMIP7-style DRS templates in CV tables (until now only CMIP6-style interpretation was supported)
- Add option "verification_against_tables" to choose between verification against esgvoc and CV-tables
- This is WIP: Until esgvoc is fully supported by the CORDEX-CMIP6 checker, verification_against_tables=True is the default and any other setting will be ignored for now.
  - Adjusting several CORDEX-CMIP6 checks to skip the parts of the checks that require CV tables
  - ToDo: make use of esgvoc for these checks
- check_attributes_match_filename: Added CORDEX-CMIP6 filename pattern and reworked project identification

Updates with regards to CMIP6/7 checker:
- check_attributes_match_filename: reworked project identification - instead of trying to identify the project from the file metadata, the chosen checker (eg. `wcrp_cmip7`) will decide which DRS filename pattern is used. I am not sure if the `filename_template_keys` parameter is still necessary or what it can be used for.

@Ayoubnac1 This could be merged for the next release. I will be working on the esgvoc checks that shall replace the CV checks asap, but this will be part of another PR.