### PR TITLE
Remove license_id attribute from global attributes configuration

### DIFF
--- a/checks/variable_checks/check_coords_cordex_cmip6.py
+++ b/checks/variable_checks/check_coords_cordex_cmip6.py
@@ -34,9 +34,15 @@ def check_lon_value_range(CheckerObject, severity=BaseCheck.MEDIUM):
         testctx.add_pass()
         return [testctx.to_result()]
 
+    # Get domain_id from global attributes
+    domain_id = CheckerObject._get_attr("domain_id", default=False)
+
     # Check if longitude coordinates are strictly monotonically increasing
     if lon.ndim != 2:
         testctx.add_failure("The longitude coordinate should have two dimensions.")
+    elif domain_id.startswith('ARC') or domain_id.startswith('ANT'):
+        # The polar domains are exempt from monotony tests
+        testctx.add_pass()
     else:
         increasing_0 = ((lon[1:, :].data - lon[:-1, :].data) > 0).all()
         increasing_1 = ((lon[:, 1:].data - lon[:, :-1].data) > 0).all()
@@ -74,13 +80,13 @@ def check_lon_value_range(CheckerObject, severity=BaseCheck.MEDIUM):
         )
 
     # Check if longitude coordinates have absolute values as small as possible
-    abs = (lon > 180).any() and (xr.where(lon >= 180, lon - 360, lon) >= -180).all()
-    if not abs:
-        testctx.add_pass()
-    else:
+    # If values are monotonic increasing, only the case 180 <= lon [< 360] is problematic
+    if lon.min() >= 180:
         testctx.add_failure(
-            "Longitude values are required to take the smalles absolute value in the range [-180, 360]."
+            "Longitude values are required to take the smallest absolute value in the range [-180, 360]."
         )
+    else:
+        testctx.add_pass()
 
     return [testctx.to_result()]
 

--- a/checks/variable_checks/check_coords_cordex_cmip6.py
+++ b/checks/variable_checks/check_coords_cordex_cmip6.py
@@ -35,13 +35,13 @@ def check_lon_value_range(CheckerObject, severity=BaseCheck.MEDIUM):
         return [testctx.to_result()]
 
     # Get domain_id from global attributes
-    domain_id = CheckerObject._get_attr("domain_id", default=False)
+    domain_id = CheckerObject._get_attr("domain_id", default="")
 
     # Check if longitude coordinates are strictly monotonically increasing
     if lon.ndim != 2:
         testctx.add_failure("The longitude coordinate should have two dimensions.")
     elif domain_id.startswith('ARC') or domain_id.startswith('ANT'):
-        # The polar domains are exempt from monotony tests
+        # The polar domains are exempt from monotony tests because they cross both the meridian and anti-meridian
         testctx.add_pass()
     else:
         increasing_0 = ((lon[1:, :].data - lon[:-1, :].data) > 0).all()

--- a/plugins/cmip6/config/wcrp/global_attributes.toml
+++ b/plugins/cmip6/config/wcrp/global_attributes.toml
@@ -91,13 +91,6 @@ value_type = "str"
 is_required = false
 pattern = ".*"
 
-[global.attributes.license_id]
-# Checks ATTR001 ATTR002 ATTR003 ATTR004
-severity = "H"
-value_type = "str"
-is_required = true
-cv_source_collection = "license_id"
-
 [global.attributes.nominal_resolution]
 # Checks ATTR001 ATTR002 ATTR003 ATTR004
 severity = "H"


### PR DESCRIPTION
Hi, 

As explained in #28, the [CMIP6_CVs](https://github.com/WCRP-CMIP/CMIP6_CVs/blob/main/CMIP6_required_global_attributes.json) do not require **License_id** as one of **required_global_attributes**

There is also no license_id collection....

I have removed it from license_id.

 