### PR TITLE
Skip VAR005 monotonicity check for auxiliary coordinates

### DIFF
--- a/plugins/cmip6/cmip6.py
+++ b/plugins/cmip6/cmip6.py
@@ -712,15 +712,19 @@ class Cmip6ProjectCheck(WCRPBaseCheck):
 
             # monotonicity
             if getattr(rule, "monotonicity", None):
-                sev = _sev(rule.monotonicity.severity, default=BaseCheck.MEDIUM)
-                res.extend(
-                    check_coordinate_monotonicity(
-                        ds,
-                        coord_name=cname,
-                        direction=rule.monotonicity.direction,
-                        severity=sev,
+                # CF allows auxiliary coordinates (e.g. lat/lon attached to a
+                # generic cell dimension on unstructured grids) to be non-monotonic.
+                # Only apply the strict-monotonicity check to dimension coords.
+                if cname in ds.dimensions:
+                    sev = _sev(rule.monotonicity.severity, default=BaseCheck.MEDIUM)
+                    res.extend(
+                        check_coordinate_monotonicity(
+                            ds,
+                            coord_name=cname,
+                            direction=rule.monotonicity.direction,
+                            severity=sev,
+                        )
                     )
-                )
 
             # TIME001
             if getattr(rule, "squareness", None):

--- a/plugins/cmip7/cmip7.py
+++ b/plugins/cmip7/cmip7.py
@@ -689,15 +689,19 @@ class Cmip7ProjectCheck(WCRPBaseCheck):
 
             # monotonicity
             if rule.monotonicity:
-                sev = self.get_severity(rule.monotonicity.severity)
-                res.extend(
-                    check_coordinate_monotonicity(
-                        ds,
-                        coord_name=cname,
-                        direction=rule.monotonicity.direction,
-                        severity=sev,
+                # CF allows auxiliary coordinates (e.g. lat/lon attached to a
+                # generic cell dimension on unstructured grids) to be non-monotonic.
+                # Only apply the strict-monotonicity check to dimension coords.
+                if cname in ds.dimensions:
+                    sev = self.get_severity(rule.monotonicity.severity)
+                    res.extend(
+                        check_coordinate_monotonicity(
+                            ds,
+                            coord_name=cname,
+                            direction=rule.monotonicity.direction,
+                            severity=sev,
+                        )
                     )
-                )
 
             # TIME001
             if rule.squareness:


### PR DESCRIPTION
Closes #33.

## Problem

CF only requires strict monotonicity for *dimension* coordinates. Auxiliary coordinates attached to a generic cell dimension on unstructured grids (e.g. FESOM2, ICON, MPAS native output) are explicitly allowed to be non-monotonic (CF 1.11 §5).

Today the per-coordinate TOML rule for `lat`/`lon` fires on any variable matching the rule's name, producing mandatory `[VAR005] Coordinate monotonicity for 'lat'/'lon'` failures that block ESGF publication of native unstructured output even when the file is otherwise CF / CMIP7 compliant.

## Fix

In both `plugins/cmip7/cmip7.py::check_Coordinates` and `plugins/cmip6/cmip6.py::check_Coordinates`, gate the `check_coordinate_monotonicity` invocation behind `cname in ds.dimensions`, so the check only runs for dimension coordinates. Auxiliary coordinates with the same name (e.g. `lat(nod2)`) are silently skipped.

## Verification

Tested locally on DKRZ Levante against the sample NetCDF described in #33 (`/work/ab0246/a270092/share/cc-plugin-wcrp-issue-33/sample_unstructured.nc`, 126 858 unstructured FESOM2 nodes, `lat(nod2)` and `lon(nod2)` as auxiliary coords).

Before the patch: 2 mandatory `VAR005` findings. After the patch: 0 `VAR005` mentions in the report. No other checks changed.

The CMIP6 path is left in sync but no equivalent CMIP6 sample was tested; the change is mechanically the same as the CMIP7 path.