### PR TITLE
cmip7: fall back to `variable_id` when CF detection finds zero geophysical variables

### DIFF
--- a/plugins/cmip7/cmip7.py
+++ b/plugins/cmip7/cmip7.py
@@ -248,6 +248,19 @@ class Cmip7ProjectCheck(WCRPBaseCheck):
         ctx = TestCtx(severity, "Geophysical Variable Detection")
 
         if len(geo_vars) == 0:
+            # CF detection returns zero candidates for files whose data
+            # variable carries flag_meanings (compliance-checker's
+            # is_geophysical heuristic treats those as QC flags). CMIP7
+            # region-selector fx files (basin, siline, ...) are flag-valued
+            # by spec but ARE the geophysical variable of the file. Fall
+            # back to the global variable_id attribute, which CMIP7 defines
+            # as the single geophysical variable of the file, when the
+            # named variable exists in the dataset.
+            vid = getattr(ds, "variable_id", None)
+            vid = str(vid) if vid else None
+            if vid and vid in ds.variables:
+                self._geo_var_cache = vid
+                return vid, res
             ctx.add_failure("No geophysical variable detected in the file.")
             res.append(ctx.to_result())
             return None, res


### PR DESCRIPTION
Closes #48.

CMIP7 region-selector fx files (`basin`, `siline`, similar) carry their data variable as a CF flag-valued integer (`flag_values` + `flag_meanings` mapping integer codes to region/section names). `compliance_checker.cf.util.is_geophysical` excludes any variable with `flag_meanings` from the geophysical-variable set as a heuristic for status flags. The exclusion is right for QC flags but wrong for these region selectors, whose `standard_name` is `region` not `status_flag`, and which ARE the file's data variable by CMIP7 design.

The existing `variable_id` disambiguation in `_get_geo_var` only fires when CF returned multiple candidates. When CF returns zero (the basin/siline case) the function bails with "No geophysical variable detected in the file." at HIGH severity, which blocks ESGF publication.

This PR extends the `variable_id` fallback to the zero-candidate branch. If CF detection finds nothing and the global `variable_id` attribute names an existing variable, accept that variable as the file's geophysical variable. The strict CF heuristic stays as the primary path; the fallback only kicks in when both (a) CF found zero candidates AND (b) the CMIP7-canonical `variable_id` attribute is present.

Verified locally against an AWI-ESM3-4-2-veg-HR basin fx file (CMIP7 `basin.ti-u-hxy-u.fx.glb`). Pre-patch: HIGH "No geophysical variable detected in the file." Post-patch: pass.