### PR TITLE
cordex-cmip6: Allow for 1D lat/lon

### DIFF
--- a/checks/attribute_checks/check_attrs_cordex_cmip6.py
+++ b/checks/attribute_checks/check_attrs_cordex_cmip6.py
@@ -91,7 +91,20 @@ def check_grid_mapping(CheckerObject, severity=BaseCheck.MEDIUM):
                     f"but is of type '{CheckerObject.ds[crs].dtype} ({CheckerObject.ds[crs].dtype.kind})'."
                 )
         else:
-            if grid_mapping_optional:
+            has_1d_lat_lon = (
+                "lat" in CheckerObject.xrds
+                and "lon" in CheckerObject.xrds
+                and CheckerObject.xrds["lat"].ndim == 1
+                and CheckerObject.xrds["lon"].ndim == 1
+            )
+            if has_1d_lat_lon:
+                grid_mapping_name = "latitude_longitude"
+                testctx.add_failure(
+                    "No grid_mapping variable found. For regular latitude-longitude grids, "
+                    "it is recommended to define a grid_mapping variable with grid_mapping_name "
+                    "'latitude_longitude' to provide the Earth radius."
+                )
+            elif grid_mapping_optional:
                 testctx.add_pass()
             else:
                 testctx.add_failure(
@@ -217,18 +230,18 @@ def check_domain_id(CheckerObject, severity=BaseCheck.MEDIUM, use_esgvoc=False):
         )
         return [testctx.to_result()]
 
-    # Rectilinear case: lat and lon must be 1D
-    #  (would also be the case for unstructured grids, but those are not allowed in CORDEX-CMIP6)
-    if CheckerObject.xrds[lat].ndim == 1 and CheckerObject.xrds[lon].ndim == 1:
-        if not domain_id.endswith("i"):
+    # If the domain_id ends in "i" (interpolated grid), we expect 1D lat and lon coordinates 
+    if domain_id.endswith("i"):
+        if CheckerObject.xrds[lat].ndim != 1 or CheckerObject.xrds[lon].ndim != 1:
             testctx.add_failure(
-                "The global attribute 'domain_id' is not compliant with the archive specifications "
-                f"('domain_id' should get the suffix 'i' in case of a rectilinear grid): '{domain_id}'."
+                "The global attribute 'domain_id' indicates an interpolated grid (suffix 'i'), "
+                f"which requires 1D latitude and longitude coordinate variables. "
+                f"Found lat ndim={CheckerObject.xrds[lat].ndim}, lon ndim={CheckerObject.xrds[lon].ndim}."
             )
         else:
             testctx.add_pass()
-            domain_id = domain_id[:-1]
     else:
+        # Non-i domains are allowed to have 1D or 2D lat/lons.
         testctx.add_pass()
 
     # Do not run comparison against CV if esgvoc is used

--- a/checks/attribute_checks/check_attrs_cordex_cmip6.py
+++ b/checks/attribute_checks/check_attrs_cordex_cmip6.py
@@ -104,6 +104,31 @@ def check_grid_mapping(CheckerObject, severity=BaseCheck.MEDIUM):
     else:
         testctx.add_pass()
 
+    # lat and lon must be present for all grid mappings. For regular
+    # latitude-longitude grids they are 1D; for all other mappings they are 2D.
+    if grid_mapping_name and grid_mapping_name in gmallowed:
+        if "lat" not in CheckerObject.xrds or "lon" not in CheckerObject.xrds:
+            testctx.add_failure(
+                f"The grid_mapping_name '{grid_mapping_name}' requires the variables"
+                " 'lat' and 'lon' to be present in the file."
+            )
+        elif grid_mapping_name == "latitude_longitude":
+            if CheckerObject.xrds["lat"].ndim != 1 or CheckerObject.xrds["lon"].ndim != 1:
+                testctx.add_failure(
+                    "The grid_mapping_name 'latitude_longitude' requires the variables"
+                    " 'lat' and 'lon' to be 1D."
+                )
+            else:
+                testctx.add_pass()
+        else:
+            if CheckerObject.xrds["lat"].ndim != 2 or CheckerObject.xrds["lon"].ndim != 2:
+                testctx.add_failure(
+                    f"The grid_mapping_name '{grid_mapping_name}' requires the variables"
+                    " 'lat' and 'lon' to be 2D."
+                )
+            else:
+                testctx.add_pass()
+
     # rlat, rlon or y, x must be present in file, depending on the grid_mapping_name
     if grid_mapping_name and grid_mapping_name in gmallowed:
         if grid_mapping_name in ["lambert_conformal_conic", "mercator"]:
@@ -115,12 +140,26 @@ def check_grid_mapping(CheckerObject, severity=BaseCheck.MEDIUM):
                 )
             else:
                 testctx.add_pass()
-        else:
+        elif grid_mapping_name == "rotated_latitude_longitude":
             if "rlat" not in CheckerObject.xrds or "rlon" not in CheckerObject.xrds:
                 testctx.add_failure(
                     "The grid_mapping_name 'rotated_latitude_longitude' requires the variables"
                     " 'rlat' and 'rlon' to be present in the file defining the native"
                     " coordinate system used by the RCM."
+                )
+            else:
+                testctx.add_pass()
+        elif grid_mapping_name == "latitude_longitude":
+            if (
+                "rlat" in CheckerObject.xrds
+                or "rlon" in CheckerObject.xrds
+                or "y" in CheckerObject.xrds
+                or "x" in CheckerObject.xrds
+            ):
+                testctx.add_failure(
+                    "The grid_mapping_name 'latitude_longitude' does not require"
+                    " 'rlat', 'rlon', 'y', or 'x' coordinate variables; 'lat' and"
+                    " 'lon' are the coordinate variables in this case."
                 )
             else:
                 testctx.add_pass()

--- a/checks/variable_checks/check_coords_cordex_cmip6.py
+++ b/checks/variable_checks/check_coords_cordex_cmip6.py
@@ -33,13 +33,35 @@ def check_lon_value_range(CheckerObject, severity=BaseCheck.MEDIUM):
         testctx.add_pass()
         return [testctx.to_result()]
 
+    grid_mapping_name = False
+    if len(CheckerObject.varname) > 0:
+        crs = getattr(
+            CheckerObject.ds.variables[CheckerObject.varname[0]], "grid_mapping", False
+        )
+        if crs:
+            grid_mapping_name = getattr(
+                CheckerObject.ds.variables[crs], "grid_mapping_name", False
+            )
+
     # Get domain_id from global attributes
     domain_id = CheckerObject._get_attr("domain_id", default="")
     if not isinstance(domain_id, str):
         domain_id = ""
 
     # Check if longitude coordinates are strictly monotonically increasing
-    if lon.ndim != 2:
+    if grid_mapping_name == "latitude_longitude":
+        if lon.ndim != 1:
+            testctx.add_failure(
+                "The longitude coordinate should have one dimension for grid_mapping_name"
+                " 'latitude_longitude'."
+            )
+        elif ((lon[1:].data - lon[:-1].data) > 0).all():
+            testctx.add_pass()
+        else:
+            testctx.add_failure(
+                "The longitude coordinate should be strictly monotonically increasing."
+            )
+    elif lon.ndim != 2:
         testctx.add_failure("The longitude coordinate should have two dimensions.")
     elif (
         domain_id.startswith("ARC")
@@ -114,6 +136,20 @@ def check_horizontal_axes_bounds(CheckerObject, severity=BaseCheck.MEDIUM):
     check_id = "CDXV002"
     desc = f"[{check_id}] Existence of horizontal axes bounds"
     testctx = TestCtx(severity, desc)
+
+    grid_mapping_name = False
+    if len(CheckerObject.varname) > 0:
+        crs = getattr(
+            CheckerObject.ds.variables[CheckerObject.varname[0]], "grid_mapping", False
+        )
+        if crs:
+            grid_mapping_name = getattr(
+                CheckerObject.ds.variables[crs], "grid_mapping_name", False
+            )
+
+    if grid_mapping_name == "latitude_longitude":
+        testctx.add_pass()
+        return [testctx.to_result()]
 
     if "X" in CheckerObject.xrds.cf.bounds and "Y" in CheckerObject.xrds.cf.bounds:
         testctx.add_pass()

--- a/checks/variable_checks/check_coords_cordex_cmip6.py
+++ b/checks/variable_checks/check_coords_cordex_cmip6.py
@@ -42,6 +42,17 @@ def check_lon_value_range(CheckerObject, severity=BaseCheck.MEDIUM):
             grid_mapping_name = getattr(
                 CheckerObject.ds.variables[crs], "grid_mapping_name", False
             )
+        else:
+            # If no grid_mapping is present, but lat and lon are 1D, we assume it's a latitude_longitude grid
+            has_1d_lat_lon = (
+                "lat" in CheckerObject.xrds
+                and "lon" in CheckerObject.xrds
+                and CheckerObject.xrds["lat"].ndim == 1
+                and CheckerObject.xrds["lon"].ndim == 1
+            )
+            
+            if has_1d_lat_lon:
+                grid_mapping_name = "latitude_longitude"
 
     # Get domain_id from global attributes
     domain_id = CheckerObject._get_attr("domain_id", default="")
@@ -137,6 +148,14 @@ def check_horizontal_axes_bounds(CheckerObject, severity=BaseCheck.MEDIUM):
     desc = f"[{check_id}] Existence of horizontal axes bounds"
     testctx = TestCtx(severity, desc)
 
+    # Check if we have 1D lat/lon (regular lat/lon grid)
+    has_1d_lat_lon = (
+        "lat" in CheckerObject.xrds
+        and "lon" in CheckerObject.xrds
+        and CheckerObject.xrds["lat"].ndim == 1
+        and CheckerObject.xrds["lon"].ndim == 1
+    )
+
     grid_mapping_name = False
     if len(CheckerObject.varname) > 0:
         crs = getattr(
@@ -146,9 +165,20 @@ def check_horizontal_axes_bounds(CheckerObject, severity=BaseCheck.MEDIUM):
             grid_mapping_name = getattr(
                 CheckerObject.ds.variables[crs], "grid_mapping_name", False
             )
+        else:
+            if has_1d_lat_lon:
+                grid_mapping_name = "latitude_longitude"
 
-    if grid_mapping_name == "latitude_longitude":
-        testctx.add_pass()
+    if grid_mapping_name == "latitude_longitude" or has_1d_lat_lon:
+        # Check if lat/lon bounds are defined (since they are the native horizontal axes)
+        if ("lat_bnds" in CheckerObject.xrds and "lon_bnds" in CheckerObject.xrds) or (
+            "vertices_lat" in CheckerObject.xrds and "vertices_lon" in CheckerObject.xrds
+        ):
+            testctx.add_pass()
+        else:
+            testctx.add_failure(
+                f"It is {severity_word(severity)} for the horizontal axes variables 'lat' and 'lon' to have bounds defined."
+            )
         return [testctx.to_result()]
 
     if "X" in CheckerObject.xrds.cf.bounds and "Y" in CheckerObject.xrds.cf.bounds:
@@ -183,6 +213,19 @@ def check_lat_lon_bounds(CheckerObject, severity=BaseCheck.MEDIUM):
     check_id = "CDXV001"
     desc = f"[{check_id}] Existence of latitude and longitude bounds"
     testctx = TestCtx(severity, desc)
+
+    # If lat/lon are 1D, CDXV001 should pass early because there are no 2D lat/lon fields.
+    # The 1D lat/lon bounds check will be handled by CDXV002 (horizontal axes bounds).
+    has_1d_lat_lon = (
+        "lat" in CheckerObject.xrds
+        and "lon" in CheckerObject.xrds
+        and CheckerObject.xrds["lat"].ndim == 1
+        and CheckerObject.xrds["lon"].ndim == 1
+    )
+
+    if has_1d_lat_lon:
+        testctx.add_pass()
+        return [testctx.to_result()]
 
     if (
         "longitude" in CheckerObject.xrds.cf.bounds


### PR DESCRIPTION
These are modifications to allow for regular grids in CORDEX-CMIP6 (e.g. i-grids, or the output from some components which are delivered in this way https://github.com/WCRP-CORDEX/data-request-table/issues/114 )

I pointed the PR to the develop branchh, although I see that the master is ahead of develop (?).