### PR TITLE
TIME001: switch _trunc to _round to avoid float-precision phantom mismatches

### DIFF
--- a/checks/time_checks/check_time_squareness.py
+++ b/checks/time_checks/check_time_squareness.py
@@ -13,9 +13,19 @@ NDECIMALS = 6
 _TIME_RANGE_RE = re.compile(r"_(\d{4,14})-(\d{4,14})(?:-clim)?\.nc$", re.IGNORECASE)
 
 
-def _trunc(arr: np.ndarray, ndecs: int) -> np.ndarray:
+def _round(arr: np.ndarray, ndecs: int) -> np.ndarray:
+    # Round (not truncate) to ``ndecs`` decimal places before comparison.
+    # ``np.trunc`` was used here previously, but it floors toward zero and
+    # is sensitive to round-trip float64 precision: a theoretical value
+    # computed as ``first + i*step`` accumulates a per-index epsilon
+    # (~5e-17) that, after multiplying by 1e6, falls just below the next
+    # integer and trunc drops it. The file's stored value can be exact at
+    # the same precision, so the two land in different 1e-6 buckets and a
+    # phantom mismatch fires even though the values agree at well below
+    # the check's resolution. ``np.round`` (banker's rounding to nearest
+    # even) is unaffected by ulp-level precision drift.
     f = 10.0 ** int(ndecs)
-    return np.trunc(arr * f) / f
+    return np.round(arr * f) / f
 
 
 def _get_ds_path(ds) -> str:
@@ -279,9 +289,10 @@ def check_time_squareness(
             )
             cur = nxt
 
-    # Compare after truncation (nctime spirit)
-    a_t = _trunc(actual, NDECIMALS)
-    t_t = _trunc(theo, NDECIMALS)
+    # Compare after rounding to NDECIMALS places. See _round docstring
+    # for why this is np.round and not np.trunc.
+    a_t = _round(actual, NDECIMALS)
+    t_t = _round(theo, NDECIMALS)
 
     bad = np.where(a_t != t_t)[0]
     if bad.size:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
   "pyfive >= 1.1.1",
   "pydantic>=2.12.5",
 ]
-version = "2.3.1"
+version = "2.3.2"
 
 [project.entry-points."compliance_checker.suites"]
 


### PR DESCRIPTION
## Symptom

Running TIME001 against a CMIP7 1hr tavg file with canonical midpointed time stamps trips at HIGH with messages of the form:

```
[TIME001] Check Time Squareness
Mismatch at index 7: expected 0.312499, got 0.312500.
(table_id=A1hr, frequency=1hr, var=clt, midpoint=True)
```

The file's stored stamps are bit-exact canonical midpoints: `1/48, 3/48, 5/48, 7/48, ..., 15/48 = 0.3125`. The difference between expected and got displayed values is `1e-6` days (~86 ms), but the actual numerical difference between `theo[7]` and `actual[7]` is `5.5e-17` days (~5 picoseconds — machine epsilon).

## Root cause

[`check_time_squareness.py`](https://github.com/ESGF/cc-plugin-wcrp/blob/master/checks/time_checks/check_time_squareness.py) currently rounds to 6 decimal places via `np.trunc`:

```python
def _trunc(arr: np.ndarray, ndecs: int) -> np.ndarray:
    f = 10.0 ** int(ndecs)
    return np.trunc(arr * f) / f
```

`np.trunc` floors toward zero. The theoretical value is built as:

```python
n0 = float(cftime.date2num(filename_start)) = 0.0
n1 = float(cftime.date2num(filename_start + 1h)) = 1/24
step_num = n1 - n0
first = (n0 + n1) / 2
theo[i] = first + i * step_num
```

At index 7, the float64 sum `1/48 + 7*1/24` lands at `0.31249999999999994` (the `5.5e-17` deficit from `1.0`'s representation). After `* 1e6`:

- `trunc(312499.9999...) = 312499 → 0.312499`
- `trunc(312500.0) = 312500 → 0.312500`

Different 1e-6 buckets, phantom mismatch.

`np.round` (banker's rounding to nearest even) is unaffected:

- `round(312499.9999...) = 312500 → 0.312500`
- `round(312500.0) = 312500 → 0.312500`

Same bucket, match.

## Real-data verification

Against an AWI-ESM3-4-2-veg-HR piControl year (cli94, 538 files):

| | pre-patch | post-patch |
|---|---:|---:|
| Sub-daily TIME001 HIGH | 45 | 0 |

All 45 pre-patch failures had the same shape: `expected 0.X12499, got 0.X12500` at some index, where the file's stored stamps were bit-exact canonical midpoints.

## Why this is safe

The change matters only at +/- 1 ulp of the truncation boundary — `~5e-17` days. The check's resolution is `1e-6` days = 86 ms. Real time-axis defects in model output are seconds-to-minutes (10⁵-10⁷ ulps above the boundary), so `round` vs `trunc` is indistinguishable for them. The patch only un-flags phantom mismatches at the boundary, not real defects.

## Scope

One file (`check_time_squareness.py`), two changes:
- `_trunc` renamed to `_round`, body switches `np.trunc` → `np.round`. Detailed comment added.
- Two call sites updated.

No tests added — the repo has no existing TIME001 tests, and the fix is small enough to reason about without infrastructure setup.
